### PR TITLE
feat: double clicking sub list item row triggers centerPlayerOnTokens…

### DIFF
--- a/src/components/InitiativeList/InitiativeSubListItem.tsx
+++ b/src/components/InitiativeList/InitiativeSubListItem.tsx
@@ -129,6 +129,7 @@ const InitiativeSubListItem: React.FC<{
       draggable={true}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
+      onDoubleClick={handleDoubleClick}
     >
       <div className={clsx(['sub-list-item-token', { 'no-turn': !hasTurn }])}>
         <img
@@ -137,7 +138,6 @@ const InitiativeSubListItem: React.FC<{
           onClick={(event: React.MouseEvent<HTMLDivElement>) => {
             handleClick(event)
           }}
-          onDoubleClick={handleDoubleClick}
           onMouseEnter={() => {
             setMouseOverToken(true)
           }}


### PR DESCRIPTION
Implements update to close https://github.com/dayvar14/obr-draw-steel/issues/54

Just moves event handler up to the InitiativeSubListItem top-level element instead of just the token icon. Result is that double clicking on the icon or the row centers the user's view on the token. 