### PR TITLE
feat: wire up player access settings to enforce turn permissions

### DIFF
--- a/src/components/InitiativeList/InitiativeSubListItem.tsx
+++ b/src/components/InitiativeList/InitiativeSubListItem.tsx
@@ -13,6 +13,7 @@ import ReactionUnfilledIcon from '@icons/reaction_unfilled.svg?react'
 import HamburgerMenuDotsIcon from '@icons/hamburger_menu_dots.svg?react'
 import EyeClosedIcon from '@icons/eye_closed.svg?react'
 import { PLACE_HOLDER_TOKEN_IMAGE } from 'config'
+import { SceneContext } from 'context/SceneContext'
 
 const InitiativeSubListItem: React.FC<{
   groupId: string
@@ -25,11 +26,12 @@ const InitiativeSubListItem: React.FC<{
   const permissionContext = useContext(PermissionContext)
   const playerContext = useContext(PlayerContext)
   const partyContext = useContext(PartyContext)
+  const sceneContext = useContext(SceneContext)
   const [imageSrc, setImageSrc] = useState<string>(tokens[0].imageUrl)
 
-  if (!playerContext || !permissionContext || !partyContext) {
+  if (!playerContext || !permissionContext || !partyContext || !sceneContext) {
     throw new Error(
-      'PlayerContext, PermissionContext, or PartyContext is undefined',
+      'PlayerContext, PermissionContext, PartyContext, or SceneContext is undefined',
     )
   }
 
@@ -50,7 +52,10 @@ const InitiativeSubListItem: React.FC<{
 
   const isOwner = ownerIds.has(playerContext.playerState.id)
 
-  const hasModifyPermissions = isGM || !isOwnerOnly || (isOwnerOnly && isOwner)
+  const canUpdateAnyTurn = sceneContext.settings.playerAccess.canModifyAllTurns
+  // if players can only update their own tokens, then check to make sure they are the owner. Otherwise the player cannot modify
+  const hasOwnerPermission = sceneContext.settings.playerAccess.canSetTurnIfPlayerOwned ? isOwnerOnly && isOwner : false
+  const hasModifyPermissions = isGM || canUpdateAnyTurn || hasOwnerPermission
 
   const playerOwners: Player.PlayerState[] = []
 

--- a/src/components/SettingsList/SettingsList.tsx
+++ b/src/components/SettingsList/SettingsList.tsx
@@ -87,13 +87,15 @@ const SettingsList = () => {
               </label>
             </div>
           </div>
-          <div className='settings-item'>
+          <div className={`settings-item ${unsavedSettings.playerAccess.canModifyAllTurns ? 'settings-item-disabled' : ''}`}
+            title="Only applies if the player permission 'Owner Only' is enabled.">
             <p>Allow players to set their turns if player owned.</p>
             <div className='settings-item-input'>
-              <label className='switch'>
+              <label className={`switch ${unsavedSettings.playerAccess.canModifyAllTurns ? 'disabled' : ''}`}>
                 <input
                   type='checkbox'
                   checked={unsavedSettings.playerAccess.canSetTurnIfPlayerOwned}
+                  disabled={unsavedSettings.playerAccess.canModifyAllTurns}
                   onChange={e =>
                     handleInputChange(
                       'playerAccess',

--- a/src/components/SettingsList/SettingsList.tsx
+++ b/src/components/SettingsList/SettingsList.tsx
@@ -4,6 +4,7 @@ import { APP_VERSION } from 'config'
 import { Modal, Token } from '@obr'
 import { SceneContext } from 'context/SceneContext'
 import { useContext, useState } from 'react'
+import clsx from 'clsx'
 
 const SettingsList = () => {
   const sceneContext = useContext(SceneContext)
@@ -87,11 +88,11 @@ const SettingsList = () => {
               </label>
             </div>
           </div>
-          <div className={`settings-item ${unsavedSettings.playerAccess.canModifyAllTurns ? 'settings-item-disabled' : ''}`}
+          <div className={clsx('settings-item', {'settings-item-disabled': unsavedSettings.playerAccess.canModifyAllTurns})}
             title="Only applies if the player permission 'Owner Only' is enabled.">
             <p>Allow players to set their turns if player owned.</p>
             <div className='settings-item-input'>
-              <label className={`switch ${unsavedSettings.playerAccess.canModifyAllTurns ? 'disabled' : ''}`}>
+              <label className={clsx('switch', {'disabled': unsavedSettings.playerAccess.canModifyAllTurns})}>
                 <input
                   type='checkbox'
                   checked={unsavedSettings.playerAccess.canSetTurnIfPlayerOwned}

--- a/src/styles/common/_input.scss
+++ b/src/styles/common/_input.scss
@@ -50,9 +50,9 @@ select {
     height: map-get($space-sizes, xlarge);
 
     &.disabled {
-        cursor: not-allowed;
-        .slider:before {
-            background-color: map-get($colors, disabled-primary);
+        .slider {
+            opacity: 0.5; 
+            cursor: not-allowed;
         }
     }
 

--- a/src/styles/common/_input.scss
+++ b/src/styles/common/_input.scss
@@ -48,37 +48,54 @@ select {
     position: relative;
     width: calc(map-get($space-sizes, xlarge) + map-get($space-sizes, xlarge));
     height: map-get($space-sizes, xlarge);
-}
 
-.switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
+    &.disabled {
+        cursor: not-allowed;
+        .slider:before {
+            background-color: map-get($colors, disabled-primary);
+        }
+    }
 
-.slider {
-    -webkit-transition: 0.4s;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    transition: 0.4s;
-    cursor: pointer;
-    background-color: #ccc;
-}
+    input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
 
-.slider:before {
-    -webkit-transition: 0.4s;
-    position: absolute;
-    bottom: map-get($space-sizes, xxxsmall);
-    left: map-get($space-sizes, xxxsmall);
-    transition: 0.4s;
-    box-shadow: 0 0 10px rgba(map-get($colors, contrast), 0.3);
-    background-color: white;
-    width: map-get($space-sizes, large);
-    height: calc(map-get($space-sizes, large));
-    content: "";
+    .slider {
+        -webkit-transition: 0.4s;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        transition: 0.4s;
+        cursor: pointer;
+        background-color: #ccc;
+
+        &:before {
+            -webkit-transition: 0.4s;
+            position: absolute;
+            bottom: map-get($space-sizes, xxxsmall);
+            left: map-get($space-sizes, xxxsmall);
+            transition: 0.4s;
+            box-shadow: 0 0 10px rgba(map-get($colors, contrast), 0.3);
+            background-color: white;
+            width: map-get($space-sizes, large);
+            height: calc(map-get($space-sizes, large));
+            content: "";
+        }
+
+        /* Rounded sliders */
+        &.round {
+            border-radius: 34px;
+
+            &:before {
+                border-radius: 50%;
+            }
+
+        }
+    }
 }
 
 input:checked + .slider {
@@ -93,13 +110,4 @@ input:checked + .slider:before {
     -webkit-transform: translateX(map-get($space-sizes, xlarge));
     -ms-transform: translateX(map-get($space-sizes, xlarge));
     transform: translateX(map-get($space-sizes, xlarge));
-}
-
-/* Rounded sliders */
-.slider.round {
-    border-radius: 34px;
-}
-
-.slider.round:before {
-    border-radius: 50%;
 }

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -66,6 +66,12 @@
         flex: 1;
         padding-right: map-get($space-sizes, small);
     }
+
+    &.settings-item-disabled {
+        p {
+            color: map-get($colors, disabled-primary);
+        }
+    }
 }
 
 .settings-body-footnote {

--- a/src/styles/themes/_theme-dark.scss
+++ b/src/styles/themes/_theme-dark.scss
@@ -2,7 +2,8 @@ $colors: (
   primary: #bb99ff,
   contrast: #ffffff,
   primary-text: #ffffff,
-  background-primary: #000000
+  background-primary: #000000,
+  disabled-primary: grey
 );
 
 @import "_theme.scss";

--- a/src/styles/themes/_theme-dark.scss
+++ b/src/styles/themes/_theme-dark.scss
@@ -3,6 +3,7 @@ $colors: (
   contrast: #ffffff,
   primary-text: #ffffff,
   background-primary: #000000,
+  disabled-text: grey,
   disabled-primary: grey
 );
 

--- a/src/styles/themes/_theme-light.scss
+++ b/src/styles/themes/_theme-light.scss
@@ -3,6 +3,7 @@ $colors: (
   contrast: #000000,
   primary-text: #191b1b,
   background-primary: #ffffff,
+  disabled-text: grey,
   disabled-primary: grey
 );
 

--- a/src/styles/themes/_theme-light.scss
+++ b/src/styles/themes/_theme-light.scss
@@ -2,7 +2,8 @@ $colors: (
   primary: #9966ff,
   contrast: #000000,
   primary-text: #191b1b,
-  background-primary: #ffffff
+  background-primary: #ffffff,
+  disabled-primary: grey
 );
 
 @import "_theme.scss";


### PR DESCRIPTION
https://github.com/dayvar14/obr-draw-steel/issues/52

Changes:
- Wires up `Allow players to modify any turn.` and `Allow players to set their turns if player owned.` settings to the turn tracker. 
- Adds title to `Allow players to set their turns if player owned.` noting that this setting only applies if `Owner Only` OBR permission is enabled. 
- If `canModifyAllTurns` is enabled, then players can modify any token turns. Additionally, the `canSetTurnIfPlayerOwned` setting is marked as disabled. (Hope is this'll clue users into how these settings interact.)
- If `canModifyAllTurns` is disabled, then the players cannot modify token turns.
- If `canSetTurnIfPlayerOwned` is enabled, then players can only update their own tokens. If the `Owner Only` OBR permission isn't set, then the player cannot modify any turns. 
- Adds disabled color to light and dark css theme
