### PR TITLE
feat: Adds Round tracker

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,10 @@ https://www.svgrepo.com/svg/529906/sort-from-top-to-bottom
 ./public/icons/sword_clash.svg .public/icons/sword_clash.png Adapted from
 https://www.svgrepo.com/svg/321543/sword-clash
 
+./public/icons/reaction_filled.svg ./public/icons/reaction_unfilled.svg
+./src/icons/reaction_filled.svg ./src/icons/reaction_unfilled.svg
+https://www.svgrepo.com/svg/355330/trigger
+
 Licensed under CC by 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 # Google Fonts

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # obr-draw-steel
 
-[![version](https://img.shields.io/badge/version-0.5.2-red.svg)](https://github.com/dayvar14/obr-draw-steel/releases/tag/v0.5.2)
+[![version](https://img.shields.io/badge/version-0.6.0-red.svg)](https://github.com/dayvar14/obr-draw-steel/releases/tag/v0.6.0)
 [![GitHub Actions](https://github.com/dayvar14/obr-draw-steel/workflows/deployment/badge.svg)](https://github.com/dayvar14/obr-draw-steel/actions)
-[![commits since version](https://img.shields.io/github/commits-since/dayvar14/obr-draw-steel/v0.5.2.svg)](https://github.com/dayvar14/obr-draw-steel/compare/releases/v0.5.2...main)
+[![commits since version](https://img.shields.io/github/commits-since/dayvar14/obr-draw-steel/v0.6.0.svg)](https://github.com/dayvar14/obr-draw-steel/compare/releases/v0.6.0...main)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![github followers](https://img.shields.io/github/followers/dayvar14.svg?style=social&label=Follow&maxAge=2592000)](https://github.com/dayvar14?tab=followers)

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 > 1.0.0 along with an attempt to deploy the extension into the Owlbear Extension
 > explorer. It currently is feature complete but may contain bugs.
 
-## Draw Steel! - Owlbear Plugin
+## Draw Steel Initiative Tracker - Owlbear Plugin
 
-An unoffical MCDM Draw Steel initiave tracker for Owlbear Rodeo.
+An unoffical MCDM Draw Steel TTRPG initiave tracker for Owlbear Rodeo.
 
-Draw Steel! is a Draw Steel initiave tracker. Born out of a yearn for a digital
-initiative tracker for the Draw Steel RPG, the repo strives to provide a
+This project is a Draw Steel TTRPG initiave tracker. Born out of a yearn for a digital
+initiative tracker for the Draw Steel TTRPG, the repo strives to provide a
 initiative tracker better suited for the rotating turns between friend and foe.
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ initiative tracker better suited for the rotating turns between friend and foe.
 
 Follow this
 [guide](https://docs.owlbear.rodeo/extensions/tutorial-hello-world/install-your-extension)
-and use this [manifest link](https://obr-draw-steal.onrender.com/manifest.json)
+and use this [manifest link](https://obr-draw-steel.onrender.com/manifest.json)
 to install then extension in Owlbear.
 
 ## Maintainers

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/sword_clash.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Draw Steel!</title>
+    <title>Draw Steel Initiative Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obr-draw-steel",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "homepage": "https://dayvar14.github.io/obr-draw-steel",
   "type": "module",
   "scripts": {

--- a/popover.html
+++ b/popover.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/sword_clash.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Draw Steel!</title>
+    <title>Draw Steel Initiative Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/icons/reaction_filled.svg
+++ b/public/icons/reaction_filled.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="#000000" stroke="#000000" stroke-width="1" points="4 14 10 14 7 23 9 23 20 9 14 9 18 1 7 1"/>
+</svg>

--- a/public/icons/reaction_unfilled.svg
+++ b/public/icons/reaction_unfilled.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="none" stroke="#000000" stroke-width="1" points="4 14 10 14 7 23 9 23 20 9 14 9 18 1 7 1"/>
+</svg>

--- a/settings.html
+++ b/settings.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/sword_clash.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Draw Steel!</title>
+    <title>Draw Steel Initiatve Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/DrawSteel.tsx
+++ b/src/components/DrawSteel.tsx
@@ -40,8 +40,6 @@ const DrawSteel = () => {
   return (
     <ThemeWrapper className={'app-container'}>
       <PlayerProvider>
-        <Header />
-        <hr />
         <SceneProvider
           loadingChildren={
             <div className={'no-scene'}>
@@ -49,6 +47,8 @@ const DrawSteel = () => {
             </div>
           }
         >
+        <Header />
+        <hr />
           <PartyProvider>
             <PermissionProvider>
               <TokenProvider>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export const Header: React.FC = () => {
                 title='Refresh all turns'
                 className='rounded-square-icon-button'
                 onClick={() => {
-                  Metadata.clearAllTurns()
+                  Metadata.clearAllTurnsAndReactions()
                 }}
               >
                 <RefreshIcon className='medium filled' />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,17 +1,67 @@
 import { Metadata, Modal, Player } from '@obr'
 import RefreshIcon from '@icons/refresh.svg?react'
 import SettingsIcon from '@icons/settings.svg?react'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { PlayerContext } from 'context/PlayerContext'
-import { SceneProvider } from 'context/SceneContext'
+import { SceneContext, SceneProvider } from 'context/SceneContext'
+const numberRegex = /\d/
 
 export const Header: React.FC = () => {
   const playerContext = useContext(PlayerContext)
+  const sceneContext = useContext(SceneContext)
+  // headerRound is modeled as a string to allow interim blank states with the html inputs
+  // once a number value is entered, the number value is persisted to the scene context
+  const [headerRound, setRound] = useState<string>('0')
+  const isGM = playerContext?.playerState.role === Player.PlayerRole.GM
+
+  // necessary because on initial render, sceneContext is uninitialized.
+  // this hook updates headerRound to be the persisted value, once context is ready
+  useEffect(() => {
+    if(sceneContext?.roundCount !== undefined) {
+      setRound(`${sceneContext?.roundCount}`)
+    }
+  }, [sceneContext?.roundCount])
+
+  const incrementRound = async (): Promise<void> => {
+    updateRound(`${(+headerRound) + 1}`)
+  }
+
+  const updateRound = async (round: string) : Promise<void> => {
+    if(!round.length) { // allows the input to be blank while the user is interacting with input
+      setRound('')
+      return
+    }
+
+    if(!numberRegex.test(round)) {
+      return
+    }
+
+    // filters out nan or negative numbers
+    if(+round < 0) {
+      round = '0'
+      return
+    }
+
+    // using Number constructor here strips leading zeros
+    const roundCount = new Number(round)
+    setRound(`${roundCount}`)
+    persistRoundCount(+roundCount)
+  }
+
+  const persistRoundCount = async (round: number): Promise<void> => {
+    await sceneContext?.setRoundCount(round)
+  }
 
   return (
     <div className='app-header'>
-      <div>
-        <h1>Draw Steel!</h1>
+      <div className='app-header-round-count'>
+        <h1>Round</h1>
+        <input type='number' value={headerRound}
+          readOnly={!isGM}
+          onChange={(e) => {updateRound(e.target.value)}}
+          onKeyDown={(e) => e.key == 'Enter' && e.target.blur() }
+          onBlur={() => !headerRound.length && setRound('0')} // while the input is focused it can be blank. If blurred && blank, then default to 0
+        />
       </div>
       <div className='app-header-icons'>
         {playerContext?.playerState.role === Player.PlayerRole.GM && (
@@ -22,6 +72,7 @@ export const Header: React.FC = () => {
                 className='rounded-square-icon-button'
                 onClick={() => {
                   Metadata.clearAllTurnsAndReactions()
+                  incrementRound()
                 }}
               >
                 <RefreshIcon className='medium filled' />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,7 +10,9 @@ export const Header: React.FC = () => {
 
   return (
     <div className='app-header'>
-      <h1>Draw Steel!</h1>
+      <div>
+        <h1>Draw Steel!</h1>
+      </div>
       <div className='app-header-icons'>
         {playerContext?.playerState.role === Player.PlayerRole.GM && (
           <>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -60,7 +60,7 @@ export const Header: React.FC = () => {
           readOnly={!isGM}
           onChange={(e) => {updateRound(e.target.value)}}
           onKeyDown={(e) => e.key == 'Enter' && e.target.blur() }
-          onBlur={() => !headerRound.length && setRound('0')} // while the input is focused it can be blank. If blurred && blank, then default to 0
+          onBlur={() => !headerRound.length && updateRound('0')} // while the input is focused it can be blank. If blurred && blank, then default to 0
         />
       </div>
       <div className='app-header-icons'>

--- a/src/components/InitiativeList/InitiativeSubList.tsx
+++ b/src/components/InitiativeList/InitiativeSubList.tsx
@@ -31,6 +31,10 @@ const InitiativeSubList: React.FC<{
     new Set(tokenGroups.keys()),
   )
 
+  const [unreactedList, setUnreactedList] = useState<Set<string>>(
+    new Set(tokenGroups.keys()),
+  )
+
   const isGM = playerContext.playerState.role === Player.PlayerRole.GM
 
   const onCheckedChange: React.ComponentProps<
@@ -45,6 +49,22 @@ const InitiativeSubList: React.FC<{
         const newCheckedList = new Set<string>(checkedList)
         newCheckedList.add(groupId)
         setCheckedList(newCheckedList)
+      }
+    }
+  }
+
+  const onReactionChange: React.ComponentProps<
+    typeof InitiativeSubListItem
+  >['onReactionChange'] = (isUnreacted, groupId) => {
+    if (unreactedList) {
+      if (isUnreacted) {
+        const newUnreactedList = new Set<string>(unreactedList)
+        newUnreactedList.delete(groupId)
+        setUnreactedList(newUnreactedList)
+      } else {
+        const newUnreactedList = new Set<string>(unreactedList)
+        newUnreactedList.add(groupId)
+        setUnreactedList(newUnreactedList)
       }
     }
   }
@@ -97,6 +117,7 @@ const InitiativeSubList: React.FC<{
       groupId={groupId}
       tokens={tokenList}
       onCheckedChange={onCheckedChange}
+      onReactionChange={onReactionChange}
     />
   ))
 

--- a/src/components/InitiativeList/InitiativeSubListItem.tsx
+++ b/src/components/InitiativeList/InitiativeSubListItem.tsx
@@ -151,6 +151,7 @@ const InitiativeSubListItem: React.FC<{
       draggable={true}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
+      onDoubleClick={handleDoubleClick}
     >
       <div className={clsx(['sub-list-item-token', { 'no-turn': !hasTurn }])}>
         <img
@@ -159,7 +160,6 @@ const InitiativeSubListItem: React.FC<{
           onClick={(event: React.MouseEvent<HTMLDivElement>) => {
             handleClick(event)
           }}
-          onDoubleClick={handleDoubleClick}
           onMouseEnter={() => {
             setMouseOverToken(true)
           }}

--- a/src/components/InitiativeList/InitiativeSubListItem.tsx
+++ b/src/components/InitiativeList/InitiativeSubListItem.tsx
@@ -13,6 +13,7 @@ import ReactionUnfilledIcon from '@icons/reaction_unfilled.svg?react'
 import HamburgerMenuDotsIcon from '@icons/hamburger_menu_dots.svg?react'
 import EyeClosedIcon from '@icons/eye_closed.svg?react'
 import { PLACE_HOLDER_TOKEN_IMAGE } from 'config'
+import { SceneContext } from 'context/SceneContext'
 
 const InitiativeSubListItem: React.FC<{
   groupId: string
@@ -25,11 +26,12 @@ const InitiativeSubListItem: React.FC<{
   const permissionContext = useContext(PermissionContext)
   const playerContext = useContext(PlayerContext)
   const partyContext = useContext(PartyContext)
+  const sceneContext = useContext(SceneContext)
   const [imageSrc, setImageSrc] = useState<string>(tokens[0].imageUrl)
 
-  if (!playerContext || !permissionContext || !partyContext) {
+  if (!playerContext || !permissionContext || !partyContext || !sceneContext) {
     throw new Error(
-      'PlayerContext, PermissionContext, or PartyContext is undefined',
+      'PlayerContext, PermissionContext, PartyContext, or SceneContext is undefined',
     )
   }
 
@@ -50,7 +52,10 @@ const InitiativeSubListItem: React.FC<{
 
   const isOwner = ownerIds.has(playerContext.playerState.id)
 
-  const hasModifyPermissions = isGM || !isOwnerOnly || (isOwnerOnly && isOwner)
+  const canUpdateAnyTurn = sceneContext.settings.playerAccess.canModifyAllTurns
+  // if players can only update their own tokens, then check to make sure they are the owner. Otherwise the player cannot modify
+  const hasOwnerPermission = sceneContext.settings.playerAccess.canSetTurnIfPlayerOwned ? isOwnerOnly && isOwner : false
+  const hasModifyPermissions = isGM || canUpdateAnyTurn || hasOwnerPermission
 
   const playerOwners: Player.PlayerState[] = []
 

--- a/src/components/SettingsList/SettingsList.tsx
+++ b/src/components/SettingsList/SettingsList.tsx
@@ -38,11 +38,8 @@ const SettingsList = () => {
       <div className='settings-header'>
         <div>
           <h1>
-            Draw Steel <small>v{APP_VERSION}</small>
+            Draw Steel Initiative Tracker <small>v{APP_VERSION}</small>
           </h1>
-          <p>
-            <small>A MCDM RPG Initiative Tracker</small>
-          </p>
         </div>
 
         <div className='settings-header-icons'>

--- a/src/components/SettingsList/SettingsList.tsx
+++ b/src/components/SettingsList/SettingsList.tsx
@@ -4,6 +4,7 @@ import { APP_VERSION } from 'config'
 import { Modal, Token } from '@obr'
 import { SceneContext } from 'context/SceneContext'
 import { useContext, useState } from 'react'
+import clsx from 'clsx'
 
 const SettingsList = () => {
   const sceneContext = useContext(SceneContext)
@@ -87,13 +88,15 @@ const SettingsList = () => {
               </label>
             </div>
           </div>
-          <div className='settings-item'>
+          <div className={clsx('settings-item', {'settings-item-disabled': unsavedSettings.playerAccess.canModifyAllTurns})}
+            title="Only applies if the player permission 'Owner Only' is enabled.">
             <p>Allow players to set their turns if player owned.</p>
             <div className='settings-item-input'>
-              <label className='switch'>
+              <label className={clsx('switch', {'disabled': unsavedSettings.playerAccess.canModifyAllTurns})}>
                 <input
                   type='checkbox'
                   checked={unsavedSettings.playerAccess.canSetTurnIfPlayerOwned}
+                  disabled={unsavedSettings.playerAccess.canModifyAllTurns}
                   onChange={e =>
                     handleInputChange(
                       'playerAccess',

--- a/src/components/SettingsList/SettingsList.tsx
+++ b/src/components/SettingsList/SettingsList.tsx
@@ -149,18 +149,14 @@ const SettingsList = () => {
           </div>
         </div>
         <div>
-          <div className='settings-item'>
+          <div className={clsx('settings-item', {'settings-item-disabled': !unsavedSettings.grouping.isEnabled})}>
             <p>Group tokens created by different users</p>
             <div className='settings-item-input'>
-              <label className='switch'>
+              <label className={clsx('switch', {'disabled': !unsavedSettings.grouping.isEnabled})}>
                 <input
                   type='checkbox'
                   disabled={!unsavedSettings.grouping.isEnabled}
-                  checked={
-                    unsavedSettings.grouping.isEnabled
-                      ? unsavedSettings.grouping.groupTokensFromAllUsers
-                      : false
-                  }
+                  checked={unsavedSettings.grouping.groupTokensFromAllUsers}
                   onChange={e =>
                     handleInputChange(
                       'grouping',
@@ -175,11 +171,12 @@ const SettingsList = () => {
           </div>
         </div>
         <div>
-          <div className='settings-item'>
+          <div className={clsx('settings-item', {'settings-item-disabled': !unsavedSettings.grouping.isEnabled})}>
             <p>Grouping splitting mode</p>
             <div className='settings-item-input'>
               <select
                 id='dropdown'
+                className={clsx({'disabled': !unsavedSettings.grouping.isEnabled})}
                 disabled={!unsavedSettings.grouping.isEnabled}
                 value={unsavedSettings.grouping.groupSplittingMode}
                 onChange={e =>

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 const EXTENSION_ID = 'com.danielayvar.obr-draw-steel'
-export const APP_VERSION = '0.5.2'
+export const APP_VERSION = '0.6.0'
 
 export const SCENE_METADATA_ID = `${EXTENSION_ID}/scene-metadata-id`
 

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,10 @@ export const FOES_TOGGLE_METADATA_ID = `${EXTENSION_ID}/foes-toggle-metadata-id`
 export const TURN_TOGGLE_CONTEXT_MENU_ID = `${EXTENSION_ID}/turn-toggle`
 export const TURN_TOGGLE_METADATA_ID = `${EXTENSION_ID}/turn-toggle-metadata-id`
 
+// Metadata for deciding is a token has a reaction
+export const REACTION_TOGGLE_CONTEXT_MENU_ID = `${EXTENSION_ID}/reaction-toggle`
+export const REACTION_TOGGLE_METADATA_ID = `${EXTENSION_ID}/reaction-toggle-metadata-id`
+
 // ID prefix used to generate a group id for a token
 export const FRIENDS_GROUP_ID_PREFIX = `${EXTENSION_ID}/friends-turn-metadata-id-`
 export const FOES_GROUP_ID_PREFIX = `${EXTENSION_ID}/foes-turn-metadata-id-`

--- a/src/context/SceneContext.tsx
+++ b/src/context/SceneContext.tsx
@@ -10,6 +10,8 @@ interface SceneContextProps {
   setFriendsListOrder: (listOrder: Scene.ListOrderMetadata) => void
   foesListOrder: Scene.ListOrderMetadata
   setFoesListOrder: (listOrder: Scene.ListOrderMetadata) => void
+  roundCount: number
+  setRoundCount: (roundCount: number) => Promise<void>
 }
 
 const SceneContext = createContext<SceneContextProps | undefined>(undefined)
@@ -28,6 +30,7 @@ const SceneProvider = ({
     useState<Scene.ListOrderMetadata>()
   const [foesListOrder, setLocalFoesListOrder] =
     useState<Scene.ListOrderMetadata>()
+  const [roundCount, setLocalRoundCount] = useState<number>(0);
 
   useEffect(() => {
     OBR.scene.isReady().then(ready => {
@@ -59,6 +62,7 @@ const SceneProvider = ({
       setLocalSettings(sceneMetadata.settings)
       setLocalFriendsListOrder(sceneMetadata.listOrders.friends)
       setLocalFoesListOrder(sceneMetadata.listOrders.foes)
+      setLocalRoundCount(sceneMetadata.roundCount)
     }
   }, [sceneMetadata])
 
@@ -74,6 +78,10 @@ const SceneProvider = ({
     Scene.updateFoesListOrderMetadata(listOrder)
   }
 
+  const setRoundCount = async (roundCount: number) => {
+    await Scene.updateRoundCount(roundCount)
+  }
+
   if (sceneMetadata) {
     const contextValue: SceneContextProps = {
       sceneMetadata,
@@ -83,6 +91,8 @@ const SceneProvider = ({
       setFriendsListOrder,
       foesListOrder: foesListOrder as Scene.ListOrderMetadata,
       setFoesListOrder,
+      roundCount,
+      setRoundCount 
     }
     return (
       <SceneContext.Provider value={contextValue}>

--- a/src/icons/reaction_filled.svg
+++ b/src/icons/reaction_filled.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="#000000" stroke="none" stroke-width="1" points="4 14 10 14 7 23 9 23 20 9 14 9 18 1 7 1"/>
+</svg>

--- a/src/icons/reaction_unfilled.svg
+++ b/src/icons/reaction_unfilled.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="none" stroke="#000000" stroke-width="1" points="4 14 10 14 7 23 9 23 20 9 14 9 18 1 7 1"/>
+</svg>

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -5,17 +5,17 @@ const argument = process.argv[2]
 
 const environment = process.env.OBR_DEPLOYMENT_ENVIRONMENT
 
-let applicationName = 'Draw Steel! (Test)'
+let applicationName = 'Draw Steel Initiative Tracker (Test)'
 
 switch (environment) {
   case 'production':
     console.log('Running in a production environment.')
-    applicationName = 'Draw Steel!'
+    applicationName = 'Draw Steel Initiative Tracker'
     break
 
   case 'development':
     console.log('Running in development environment.')
-    applicationName = 'Draw Steel! (Dev)'
+    applicationName = 'Draw Steel Initiative Tracker (Dev)'
     break
 }
 
@@ -25,10 +25,10 @@ const manifest = {
   author: 'Daniel Ayvar',
   homepage_url: 'https://github.com/dayvar14/obr-draw-steel',
   manifest_version: 1,
-  description: 'An unofficial Draw Steel RPG initiative tracker for Owlbear Rodeo.',
+  description: 'An unofficial Draw Steel TTRPG initiative tracker for Owlbear Rodeo.',
   icon: '/icons/sword_clash.png',
   action: {
-    title: 'Draw Steel!',
+    title: 'Draw Steel Initiative Tracker',
     icon: '/icons/sword_clash.svg',
     popover: '/',
     height: APP_HEIGHT,

--- a/src/obr/contextmenu.ts
+++ b/src/obr/contextmenu.ts
@@ -5,11 +5,17 @@ import {
   FOES_TOGGLE_METADATA_ID,
   FRIENDS_TOGGLE_CONTEXT_MENU_ID,
   FRIENDS_TOGGLE_METADATA_ID,
+  REACTION_TOGGLE_CONTEXT_MENU_ID,
+  REACTION_TOGGLE_METADATA_ID,
   TURN_TOGGLE_CONTEXT_MENU_ID,
   TURN_TOGGLE_METADATA_ID,
 } from '../config.js'
 
-import { createToggleClickFunc, createTurnToggleClickFunc } from './itemmetadata.ts'
+import {
+  createToggleClickFunc,
+  createTurnToggleClickFunc,
+  createReactionToggleClickFunc,
+} from './itemmetadata.ts'
 
 const friendsIcons: ContextMenuIcon[] = [
   {
@@ -126,6 +132,102 @@ const turnIcons: ContextMenuIcon[] = [
       ],
     },
   },
+  {
+    icon: '/icons/flag_filled.svg',
+    label: 'Toggle Turn',
+    filter: {
+      every: [
+        { key: 'layer', value: 'CHARACTER' },
+        {
+          key: ['metadata', REACTION_TOGGLE_METADATA_ID],
+          value: undefined,
+        },
+      ],
+      some: [
+        {
+          key: ['metadata', FRIENDS_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+          coordinator: '||',
+        },
+        {
+          key: ['metadata', FOES_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+        },
+      ],
+    },
+  },
+  {
+    icon: '/icons/flag_unfilled.svg',
+    label: 'Toggle Turn',
+    filter: {
+      every: [{ key: 'layer', value: 'CHARACTER' }],
+      some: [
+        {
+          key: ['metadata', FRIENDS_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+          coordinator: '||',
+        },
+        {
+          key: ['metadata', FOES_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+        },
+      ],
+    },
+  },
+]
+
+
+const reactionIcons: ContextMenuIcon[] = [
+  {
+    icon: '/icons/reaction_filled.svg',
+    label: 'Toggle Reaction',
+    filter: {
+      every: [
+        { key: 'layer', value: 'CHARACTER' },
+        {
+          key: ['metadata', REACTION_TOGGLE_METADATA_ID],
+          value: undefined,
+        },
+      ],
+      some: [
+        {
+          key: ['metadata', FRIENDS_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+          coordinator: '||',
+        },
+        {
+          key: ['metadata', FOES_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+        },
+      ],
+    },
+  },
+  {
+    icon: '/icons/reaction_unfilled.svg',
+    label: 'Toggle Reaction',
+    filter: {
+      every: [{ key: 'layer', value: 'CHARACTER' }],
+      some: [
+        {
+          key: ['metadata', FRIENDS_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+          coordinator: '||',
+        },
+        {
+          key: ['metadata', FOES_TOGGLE_METADATA_ID],
+          value: undefined,
+          operator: '!=',
+        },
+      ],
+    },
+  },
 ]
 
 export module ContextMenu {
@@ -137,6 +239,7 @@ export module ContextMenu {
         onClick: createToggleClickFunc(
           FRIENDS_TOGGLE_METADATA_ID,
           TURN_TOGGLE_METADATA_ID,
+          REACTION_TOGGLE_METADATA_ID,
         ),
       })
 
@@ -146,6 +249,7 @@ export module ContextMenu {
         onClick: createToggleClickFunc(
           FOES_TOGGLE_METADATA_ID,
           TURN_TOGGLE_METADATA_ID,
+          REACTION_TOGGLE_METADATA_ID,
         ),
       })
 
@@ -153,6 +257,12 @@ export module ContextMenu {
         id: TURN_TOGGLE_CONTEXT_MENU_ID,
         icons: turnIcons,
         onClick: createTurnToggleClickFunc(TURN_TOGGLE_METADATA_ID),
+      })
+
+      OBR.contextMenu.create({
+        id: REACTION_TOGGLE_CONTEXT_MENU_ID,
+        icons: reactionIcons,
+        onClick: createReactionToggleClickFunc(REACTION_TOGGLE_METADATA_ID),
       })
     })
   }

--- a/src/obr/itemmetadata.ts
+++ b/src/obr/itemmetadata.ts
@@ -3,6 +3,7 @@ import OBR, { ContextMenuItem, Image, isImage } from '@owlbear-rodeo/sdk'
 import {
   FOES_TOGGLE_METADATA_ID,
   FRIENDS_TOGGLE_METADATA_ID,
+  REACTION_TOGGLE_METADATA_ID,
   TURN_TOGGLE_METADATA_ID,
 } from '../config.js'
 
@@ -114,15 +115,122 @@ const deleteTokenTurnMetadataForGroup = (
   }
 }
 
-const clearMetadata = async (metadataId: string, turnMetadataId: string) => {
+interface TokenReactionMetadata {
+  groupId: string
+}
+
+export const createReactionToggleClickFunc = (reactionMetadataId: string) => {
+  const ReactionToggleClickFunc: ContextMenuItem['onClick'] = context => {
+    const reactionToggleEnabled = context.items.every(
+      item => item.metadata[reactionMetadataId] === undefined,
+    )
+
+    if (reactionToggleEnabled) {
+      OBR.scene.items.updateItems(context.items, items =>
+        setTokenReactionMetadata(items, reactionMetadataId),
+      )
+    } else {
+      OBR.scene.items.updateItems(context.items, items =>
+        deleteTokenReactionMetadata(items, reactionMetadataId),
+      )
+    }
+  }
+  return ReactionToggleClickFunc
+}
+
+const setTokenReactionMetadata = (items: any[], tokenReactionMetadataId: string) => {
+  // We store group ids so that we can
+  const groupIds = new Set<string>()
+  const itemIds = new Set<string>()
+
+  // We toggle the turn for all tokens in the context
+  for (const item of items) {
+    if (isImage(item)) {
+      const groupId = GroupIDGenerator.generateGroupIdFromImage(item)
+      const tokenReactionMetadata: TokenReactionMetadata = {
+        groupId: GroupIDGenerator.generateGroupIdFromImage(item),
+      }
+      item.metadata[tokenReactionMetadataId] = tokenReactionMetadata
+
+      groupIds.add(groupId)
+      itemIds.add(item.id)
+    }
+  }
+
+  // We need to set the turn for all other tokens clumped with the tokens in the context
+  OBR.scene.items.updateItems(
+    item =>
+      !itemIds.has(item.id) &&
+      isImage(item) &&
+      item.metadata[tokenReactionMetadataId] === undefined &&
+      groupIds.has(GroupIDGenerator.generateGroupIdFromImage(item)),
+    items => setTokenReactionMetadataForGroup(items, tokenReactionMetadataId),
+  )
+}
+
+const setTokenReactionMetadataForGroup = (
+  items: Image[],
+  tokenReactionMetadataId: string,
+) => {
+  for (const item of items) {
+    const groupId = GroupIDGenerator.generateGroupIdFromImage(item)
+    const tokenReactionMetadata: TokenReactionMetadata = {
+      groupId: groupId,
+    }
+    item.metadata[tokenReactionMetadataId] = tokenReactionMetadata
+  }
+}
+
+const deleteTokenReactionMetadata = (items: any[], tokenReactionMetadataId: string) => {
+  // We need to know which groups to delete from
+  const groupIds = new Set<string>()
+  // We store item ids so we dont re modify itemds we already modified
+  const itemIds = new Set<string>()
+  for (const item of items) {
+    if (isImage(item)) {
+      const groupId = GroupIDGenerator.generateGroupIdFromImage(item)
+      groupIds.add(groupId)
+      itemIds.add(item.id)
+    }
+
+    delete item.metadata[tokenReactionMetadataId]
+  }
+
+  OBR.scene.items.updateItems(
+    // If item is not in the list of items we already modified, and and it shares a groupId with the items in the context
+    item =>
+      !itemIds.has(item.id) &&
+      isImage(item) &&
+      item.metadata[tokenReactionMetadataId] !== undefined &&
+      item.metadata[tokenReactionMetadataId] !== null &&
+      'groupId' in (item.metadata[tokenReactionMetadataId] as TokenReactionMetadata) &&
+      groupIds.has(
+        (item.metadata[tokenReactionMetadataId] as TokenReactionMetadata).groupId,
+      ),
+    items => deleteTokenReactionMetadataForGroup(items, tokenReactionMetadataId),
+  )
+}
+
+const deleteTokenReactionMetadataForGroup = (
+  items: Image[],
+  tokenReactionMetadataId: string,
+) => {
+  for (const item of items) {
+    delete item.metadata[tokenReactionMetadataId]
+  }
+}
+
+const clearMetadata = async (metadataId: string, turnMetadataId: string, reactionMetadataId: string) => {
   await OBR.scene.items.updateItems(
     item =>
       item.metadata[metadataId] !== undefined ||
-      item.metadata[turnMetadataId] !== undefined,
+      item.metadata[turnMetadataId] !== undefined ||
+      item.metadata[reactionMetadataId] !== undefined,
     items => {
       for (const item of items) {
         delete item.metadata[metadataId]
         delete item.metadata[turnMetadataId]
+        delete item.metadata[reactionMetadataId]
       }
     },
   )
@@ -131,6 +239,7 @@ const clearMetadata = async (metadataId: string, turnMetadataId: string) => {
 export const createToggleClickFunc = (
   metadataId: string,
   turnMetadataId: string,
+  reactionMetadataId: string,
 ) => {
   const ToggleClickFunc: ContextMenuItem['onClick'] = context => {
     const toggleEnabled = context.items.every(
@@ -148,6 +257,7 @@ export const createToggleClickFunc = (
         for (const item of items) {
           delete item.metadata[metadataId]
           delete item.metadata[turnMetadataId]
+          delete item.metadata[reactionMetadataId]
         }
       })
     }
@@ -157,19 +267,21 @@ export const createToggleClickFunc = (
 
 export module Metadata {
   export const clearFriends = async () => {
-    await clearMetadata(FRIENDS_TOGGLE_METADATA_ID, TURN_TOGGLE_METADATA_ID)
+    await clearMetadata(FRIENDS_TOGGLE_METADATA_ID, TURN_TOGGLE_METADATA_ID, REACTION_TOGGLE_METADATA_ID)
   }
 
   export const clearFoes = async () => {
-    await clearMetadata(FOES_TOGGLE_METADATA_ID, TURN_TOGGLE_METADATA_ID)
+    await clearMetadata(FOES_TOGGLE_METADATA_ID, TURN_TOGGLE_METADATA_ID, REACTION_TOGGLE_METADATA_ID)
   }
 
-  export const clearAllTurns = () => {
+  export const clearAllTurnsAndReactions = () => {
     OBR.scene.items.updateItems(
-      item => item.metadata[TURN_TOGGLE_METADATA_ID] !== undefined,
+      item => item.metadata[TURN_TOGGLE_METADATA_ID] !== undefined ||
+      item.metadata[REACTION_TOGGLE_METADATA_ID] !== undefined,
       items => {
         for (const item of items) {
           delete item.metadata[TURN_TOGGLE_METADATA_ID]
+          delete item.metadata[REACTION_TOGGLE_METADATA_ID]
         }
       },
     )
@@ -198,6 +310,35 @@ export module Metadata {
             delete item.metadata[TURN_TOGGLE_METADATA_ID]
           } else {
             item.metadata[TURN_TOGGLE_METADATA_ID] = {}
+          }
+        }
+      },
+    )
+  }
+
+  export const setReactionMetadataFromTokens = (
+    tokens: Token.Token[],
+    isChecked: boolean,
+  ) => {
+    // Ignore cases where there are no tokens
+    if (tokens.length === 0) {
+      return
+    }
+
+    const tokenIds = new Set<string>()
+
+    for (const token of tokens) {
+      tokenIds.add(token.id)
+    }
+
+    OBR.scene.items.updateItems(
+      item => tokenIds.has(item.id),
+      items => {
+        for (const item of items) {
+          if (isChecked) {
+            delete item.metadata[REACTION_TOGGLE_METADATA_ID]
+          } else {
+            item.metadata[REACTION_TOGGLE_METADATA_ID] = {}
           }
         }
       },

--- a/src/obr/scene.ts
+++ b/src/obr/scene.ts
@@ -9,7 +9,8 @@ export module Scene {
     listOrders: {
       friends: ListOrderMetadata
       foes: ListOrderMetadata
-    }
+    },
+    roundCount: number
   }
 
   export interface SettingsMetadata {
@@ -125,5 +126,11 @@ export module Scene {
     metadata: ListOrderMetadata,
   ) => {
     return updateListOrderMetadata('foes', metadata)
+  }
+
+  export const updateRoundCount = async (roundCount: number): Promise<void> => {
+    const sceneMetadata = await getSceneMetadata()
+    sceneMetadata.roundCount = roundCount
+    return updateSceneMetadata(sceneMetadata)
   }
 }

--- a/src/obr/tokens.ts
+++ b/src/obr/tokens.ts
@@ -6,6 +6,7 @@ import { GroupIDGenerator } from './common'
 import {
   FOES_TOGGLE_METADATA_ID,
   FRIENDS_TOGGLE_METADATA_ID,
+  REACTION_TOGGLE_METADATA_ID,
   TURN_TOGGLE_METADATA_ID,
 } from '../config'
 
@@ -24,6 +25,7 @@ export module Token {
     isVisible: boolean
     tokenType?: TokenType
     hasTurn: boolean
+    hasReaction: boolean
     mapPosition: {
       x: number
       y: number
@@ -261,6 +263,7 @@ export module Token {
         ? TokenType.FRIEND
         : TokenType.FOE
     const hasTurn = image.metadata[TURN_TOGGLE_METADATA_ID] !== undefined
+    const hasReaction = image.metadata[REACTION_TOGGLE_METADATA_ID] !== undefined
 
     const name = image.text.plainText ? image.text.plainText : image.name
     const groupId = GroupIDGenerator.generateGroupIdFromImage(image)
@@ -274,6 +277,7 @@ export module Token {
       isVisible: image.visible,
       tokenType: tokenType,
       hasTurn: hasTurn,
+      hasReaction: hasReaction,
       mapPosition: {
         x: image.position.x,
         y: image.position.y,

--- a/src/styles/common/_input.scss
+++ b/src/styles/common/_input.scss
@@ -9,10 +9,15 @@ input[type="number"] {
     padding-top: map-get($space-sizes, xxsmall);
     padding-bottom: map-get($space-sizes, xxsmall);
     text-align: center;
-}
 
-input[type="number"]:focus {
-    background-color: rgba(map-get($colors, contrast), 0.1);
+    &:read-only {
+        user-select: none;
+        cursor: default;
+    }
+
+    &:focus {
+        background-color: rgba(map-get($colors, contrast), 0.1);
+    }
 }
 
 input:focus {

--- a/src/styles/common/_input.scss
+++ b/src/styles/common/_input.scss
@@ -48,37 +48,54 @@ select {
     position: relative;
     width: calc(map-get($space-sizes, xlarge) + map-get($space-sizes, xlarge));
     height: map-get($space-sizes, xlarge);
-}
 
-.switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
+    &.disabled {
+        .slider {
+            opacity: 0.5; 
+            cursor: not-allowed;
+        }
+    }
 
-.slider {
-    -webkit-transition: 0.4s;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    transition: 0.4s;
-    cursor: pointer;
-    background-color: #ccc;
-}
+    input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
 
-.slider:before {
-    -webkit-transition: 0.4s;
-    position: absolute;
-    bottom: map-get($space-sizes, xxxsmall);
-    left: map-get($space-sizes, xxxsmall);
-    transition: 0.4s;
-    box-shadow: 0 0 10px rgba(map-get($colors, contrast), 0.3);
-    background-color: white;
-    width: map-get($space-sizes, large);
-    height: calc(map-get($space-sizes, large));
-    content: "";
+    .slider {
+        -webkit-transition: 0.4s;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        transition: 0.4s;
+        cursor: pointer;
+        background-color: #ccc;
+
+        &:before {
+            -webkit-transition: 0.4s;
+            position: absolute;
+            bottom: map-get($space-sizes, xxxsmall);
+            left: map-get($space-sizes, xxxsmall);
+            transition: 0.4s;
+            box-shadow: 0 0 10px rgba(map-get($colors, contrast), 0.3);
+            background-color: white;
+            width: map-get($space-sizes, large);
+            height: calc(map-get($space-sizes, large));
+            content: "";
+        }
+
+        /* Rounded sliders */
+        &.round {
+            border-radius: 34px;
+
+            &:before {
+                border-radius: 50%;
+            }
+
+        }
+    }
 }
 
 input:checked + .slider {
@@ -93,13 +110,4 @@ input:checked + .slider:before {
     -webkit-transform: translateX(map-get($space-sizes, xlarge));
     -ms-transform: translateX(map-get($space-sizes, xlarge));
     transform: translateX(map-get($space-sizes, xlarge));
-}
-
-/* Rounded sliders */
-.slider.round {
-    border-radius: 34px;
-}
-
-.slider.round:before {
-    border-radius: 50%;
 }

--- a/src/styles/common/_input.scss
+++ b/src/styles/common/_input.scss
@@ -41,6 +41,11 @@ select {
     padding-bottom: map-get($space-sizes, xxxsmall);
     padding-left: map-get($space-sizes, xsmall);
     font-family: inherit;
+
+    &.disabled {
+        opacity: 0.5; 
+        cursor: not-allowed;
+    }
 }
 
 .switch {

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -13,6 +13,18 @@
     > hr {
         opacity: 0.02;
     }
+
+    &-round-count {
+        display: flex;
+        gap: map-get($space-sizes, small);
+        align-items: center;
+
+        > input {
+            @extend h1;
+            max-width: 60px;
+            border: 1px solid rgba(map-get($colors, contrast), 0.25);
+        }
+    }
 }
 
 .app-header-icons {

--- a/src/styles/components/_initiative-sub-list-item.scss
+++ b/src/styles/components/_initiative-sub-list-item.scss
@@ -113,7 +113,7 @@
         }
     }
 
-    & > *:last-child {
+    & > * {
         margin-left: map-get($space-sizes, xxsmall);
     }
 

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -66,6 +66,12 @@
         flex: 1;
         padding-right: map-get($space-sizes, small);
     }
+
+    &.settings-item-disabled {
+        p {
+            color: map-get($colors, disabled-primary);
+        }
+    }
 }
 
 .settings-body-footnote {

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -14,6 +14,10 @@
     padding-right: map-get($space-sizes, xlarge);
     padding-bottom: map-get($space-sizes, small);
     padding-left: map-get($space-sizes, xlarge);
+
+    h1 {
+        font-size: map-get($font-sizes, normal)
+    }
 }
 
 .settings-header-icons {

--- a/src/styles/themes/_theme-dark.scss
+++ b/src/styles/themes/_theme-dark.scss
@@ -2,7 +2,9 @@ $colors: (
   primary: #bb99ff,
   contrast: #ffffff,
   primary-text: #ffffff,
-  background-primary: #000000
+  background-primary: #000000,
+  disabled-text: grey,
+  disabled-primary: grey
 );
 
 @import "_theme.scss";

--- a/src/styles/themes/_theme-light.scss
+++ b/src/styles/themes/_theme-light.scss
@@ -2,7 +2,9 @@ $colors: (
   primary: #9966ff,
   contrast: #000000,
   primary-text: #191b1b,
-  background-primary: #ffffff
+  background-primary: #ffffff,
+  disabled-text: grey,
+  disabled-primary: grey
 );
 
 @import "_theme.scss";

--- a/src/styles/utilities/_variables.scss
+++ b/src/styles/utilities/_variables.scss
@@ -28,6 +28,6 @@ $space-sizes: (
 
 $custom-sizes: (
     screen-width: 350px,
-    token-name: 210px,
+    token-name: 170px,
     token-image: 40px
 );


### PR DESCRIPTION
For #48.

@dayvar14 feel free to really go through this with a fine-toothed comb. This is my first time working with these state / effect hooks, so lmk if there's anything to tighten up. 

Features/Changes:
- Round tracker which replaces Draw Steel header.
- tracker increments when action reset button clicked.
- GM allowed to manually input round count. Input is readonly for players.
- RoundCount is persisted in the scene context. 